### PR TITLE
#200 Add org.apache.xerces to third party dependencies

### DIFF
--- a/features/org.polarsys.capella.vp.requirements.thirdparty.feature/feature.xml
+++ b/features/org.polarsys.capella.vp.requirements.thirdparty.feature/feature.xml
@@ -87,5 +87,12 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+         
+   <plugin
+         id="org.apache.xerces"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/releng/org.polarsys.capella.vp.requirements.target/tp/capella.target-definition.targetplatform
+++ b/releng/org.polarsys.capella.vp.requirements.target/tp/capella.target-definition.targetplatform
@@ -29,6 +29,7 @@ location "https://download.eclipse.org/diffmerge/releases/0.15.0/edm-coevolution
 
 location "https://download.eclipse.org/rmf/updates/releases/0.13.0" {
 	org.eclipse.rmf.reqif10.feature.feature.group
+	org.apache.xerces
 }
 
 location "https://download.eclipse.org/sphinx/releases/0.9.x" {


### PR DESCRIPTION
org.apache.xerces has been removed from Capella and is now required here to install the reqif importer feature.

Change-Id: I70779ebb4cf2d27659e584c32401cf9462fe396b